### PR TITLE
Add support for _name, _inherit, _inherits + PyCharm 2022.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = '2022.1.4'
+    version = '2022.2'
     type = 'PC'
     plugins = [
             "PythonCore"
@@ -35,5 +35,5 @@ test {
 
 patchPluginXml {
     sinceBuild = '210'
-    untilBuild = '221.*'
+    untilBuild = '222.*'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,8 +25,8 @@ intellij {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_11
-    targetCompatibility = JavaVersion.VERSION_11
+    sourceCompatibility = JavaVersion.VERSION_17
+    targetCompatibility = JavaVersion.VERSION_17
 }
 
 test {
@@ -34,6 +34,6 @@ test {
 }
 
 patchPluginXml {
-    sinceBuild = '210'
+    sinceBuild = '222.3345.131'
     untilBuild = '222.*'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,10 @@
 plugins {
-    id 'org.jetbrains.intellij' version '1.4.0'
+    id 'org.jetbrains.intellij' version '1.7.0'
     id 'java'
 }
 
 group 'me.oddlyoko'
-version '0.0.2'
+version '0.0.3'
 
 repositories {
     mavenCentral()
@@ -17,7 +17,7 @@ dependencies {
 
 // See https://github.com/JetBrains/gradle-intellij-plugin/
 intellij {
-    version = '2021.3.2'
+    version = '2022.1.4'
     type = 'PC'
     plugins = [
             "PythonCore"

--- a/src/main/java/me/oddlyoko/odoo/models/OdooModelUtil.java
+++ b/src/main/java/me/oddlyoko/odoo/models/OdooModelUtil.java
@@ -4,11 +4,13 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiManager;
+import com.intellij.psi.search.GlobalSearchScope;
 import com.jetbrains.python.psi.PyClass;
 import com.jetbrains.python.psi.PyFile;
 import me.oddlyoko.odoo.models.indexes.OdooModelIndex;
 import me.oddlyoko.odoo.models.models.ModelDescriptor;
 import me.oddlyoko.odoo.models.models.OdooModel;
+import me.oddlyoko.odoo.modules.models.OdooModule;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Collection;
@@ -123,9 +125,58 @@ public final class OdooModelUtil {
      * Retrieves all models for given project
      *
      * @param project The project
-     * @return A {@link Collection} containing all models defined in this project
+     * @return A {@link Collection} of string containing all models defined in this project
      */
     public static Collection<String> getAllModels(@NotNull Project project) {
         return OdooModelIndex.getAllModels(project);
+    }
+
+    /**
+     * Retrieves all available models for given project with given scope
+     *
+     * @param project The project
+     * @param scope   The scope
+     * @return A {@link Collection} of String containing all models defined in this project with given scope
+     */
+    public static Collection<String> getAllModels(@NotNull Project project, @NotNull GlobalSearchScope scope) {
+        return OdooModelIndex.getAllModels(project, scope);
+    }
+
+    /**
+     * Retrieves all available models for given project with given {@link OdooModule}
+     *
+     * @param project    The project
+     * @param odooModule The {@link OdooModule}
+     * @return A {@link Collection} of String containing all models defined in this project with given {@link OdooModule}
+     */
+    public static Collection<String> getAllModels(@NotNull Project project, @NotNull OdooModule odooModule) {
+        return OdooModelIndex.getAllModels(project, odooModule.getOdooPythonModuleScope(true));
+    }
+
+    /**
+     * Retrieves all {@link PyClass} instance from given id for given {@link Project}
+     *
+     * @param odooModel The id of the model
+     * @param project   The project
+     * @return A {@link List} containing all {@link PyClass} instance of given id for given {@link Project}
+     */
+    public static List<PyClass> getModelsByName(@NotNull String odooModel, @NotNull Project project) {
+        return OdooModelIndex.getModelsByName(odooModel, project);
+    }
+
+    /**
+     * Retrieves all {@link PyClass} instance from given id for given {@link Project} and scope
+     *
+     * @param odooModel The id of the project
+     * @param project   The project
+     * @param scope     The scope
+     * @return A {@link List} containing all {@link PyClass} instance of given id for given {@link Project}
+     */
+    public static List<PyClass> getModelsByName(@NotNull String odooModel, @NotNull Project project, GlobalSearchScope scope) {
+        return OdooModelIndex.getModelsByName(odooModel, project, scope);
+    }
+
+    public static List<PyClass> getModelsByName(@NotNull String odooModel, @NotNull Project project, OdooModule odooModule) {
+        return OdooModelIndex.getModelsByName(odooModel, project, odooModule.getOdooPythonModuleScope(true));
     }
 }

--- a/src/main/java/me/oddlyoko/odoo/models/OdooModelUtil.java
+++ b/src/main/java/me/oddlyoko/odoo/models/OdooModelUtil.java
@@ -77,7 +77,7 @@ public final class OdooModelUtil {
         ModelDescriptor modelDescriptor = odooPyClass.getModelDescriptor();
         if (modelDescriptor == null)
             return null;
-        return modelDescriptor.getOdooModel();
+        return modelDescriptor.odooModel();
     }
 
     /**
@@ -89,9 +89,9 @@ public final class OdooModelUtil {
      */
     public static List<PyClass> getClasses(@NotNull VirtualFile file, @NotNull Project project) {
         PsiFile psiFile = PsiManager.getInstance(project).findFile(file);
-        if (!(psiFile instanceof PyFile))
+        if (!(psiFile instanceof PyFile pyFile))
             return List.of();
-        return ((PyFile) psiFile).getTopLevelClasses();
+        return pyFile.getTopLevelClasses();
     }
 
     /**

--- a/src/main/java/me/oddlyoko/odoo/models/indexes/OdooModelIndex.java
+++ b/src/main/java/me/oddlyoko/odoo/models/indexes/OdooModelIndex.java
@@ -61,7 +61,7 @@ public class OdooModelIndex extends ScalarIndexExtension<String> {
                     ModelDescriptor descriptor = ModelDescriptor.fromPyClass(node);
                     if (descriptor == null)
                         return;
-                    result.put(descriptor.getOdooModel(), null);
+                    result.put(descriptor.odooModel(), null);
                 }
             });
             return result;
@@ -122,7 +122,7 @@ public class OdooModelIndex extends ScalarIndexExtension<String> {
                 public void visitPyClass(@NotNull PyClass node) {
                     super.visitPyClass(node);
                     ModelDescriptor descriptor = ModelDescriptor.fromPyClass(node);
-                    if (descriptor != null && odooModel.equals(descriptor.getOdooModel()))
+                    if (descriptor != null && odooModel.equals(descriptor.odooModel()))
                         result.add(node);
                 }
             });

--- a/src/main/java/me/oddlyoko/odoo/models/indexes/OdooModelIndex.java
+++ b/src/main/java/me/oddlyoko/odoo/models/indexes/OdooModelIndex.java
@@ -3,6 +3,7 @@ package me.oddlyoko.odoo.models.indexes;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.intellij.psi.PsiManager;
 import com.intellij.psi.search.GlobalSearchScope;
 import com.intellij.util.indexing.DataIndexer;
 import com.intellij.util.indexing.FileBasedIndex;
@@ -16,16 +17,15 @@ import com.jetbrains.python.psi.PyElementVisitor;
 import me.oddlyoko.odoo.models.OdooModelFilter;
 import me.oddlyoko.odoo.models.OdooModelUtil;
 import me.oddlyoko.odoo.models.models.ModelDescriptor;
-import me.oddlyoko.odoo.models.models.OdooModel;
 import me.oddlyoko.odoo.modules.OdooModuleUtil;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 /**
  * Index containing all odoo modules
@@ -91,21 +91,43 @@ public class OdooModelIndex extends ScalarIndexExtension<String> {
     }
 
     /**
-     * Retrieves all {@link OdooModel} instance from given id for given {@link Project}
+     * Retrieves all {@link PyClass} instance from given id for given {@link Project}
      *
      * @param odooModel The id of the model
      * @param project   The project
-     * @return A {@link Set} containing all {@link OdooModel} instance of given id for given {@link Project}
+     * @return A {@link List} containing all {@link PyClass} instance of given id for given {@link Project}
      */
-    public static Set<OdooModel> getOdooModels(@NotNull String odooModel, @NotNull Project project) {
-        GlobalSearchScope scope = GlobalSearchScope.projectScope(project);
-        Collection<VirtualFile> files = FileBasedIndex.getInstance().getContainingFiles(NAME, odooModel, scope);
-        return files
-                .stream()
-                .flatMap(file -> OdooModelUtil.getModels(file, project)
-                        .stream()
-                        .filter(odooModel1 -> odooModel1 != null && odooModel.equals(odooModel1.getOdooModel())))
-                .collect(Collectors.toUnmodifiableSet());
+    public static List<PyClass> getModelsByName(@NotNull String odooModel, @NotNull Project project) {
+        return getModelsByName(odooModel, project, GlobalSearchScope.projectScope(project));
+    }
+
+    /**
+     * Retrieves all {@link PyClass} instance from given id for given {@link Project} and scope
+     *
+     * @param odooModel The id of the project
+     * @param project   The project
+     * @param scope     The scope
+     * @return A {@link List} containing all {@link PyClass} instance of given id for given {@link Project}
+     */
+    public static List<PyClass> getModelsByName(@NotNull String odooModel, @NotNull Project project, GlobalSearchScope scope) {
+        Collection<VirtualFile> vFiles = FileBasedIndex.getInstance().getContainingFiles(NAME, odooModel, scope);
+        List<PyClass> result = new ArrayList<>();
+        PsiManager psiManager = PsiManager.getInstance(project);
+        vFiles.forEach(vFile -> {
+            PsiFile file = psiManager.findFile(vFile);
+            if (file == null)
+                return;
+            file.acceptChildren(new PyElementVisitor() {
+                @Override
+                public void visitPyClass(@NotNull PyClass node) {
+                    super.visitPyClass(node);
+                    ModelDescriptor descriptor = ModelDescriptor.fromPyClass(node);
+                    if (descriptor != null && odooModel.equals(descriptor.getOdooModel()))
+                        result.add(node);
+                }
+            });
+        });
+        return result;
     }
 
     /**

--- a/src/main/java/me/oddlyoko/odoo/models/models/OdooModel.java
+++ b/src/main/java/me/oddlyoko/odoo/models/models/OdooModel.java
@@ -19,7 +19,7 @@ public class OdooModel extends PyClassImpl {
 
     public String getOdooModel() {
         ModelDescriptor descriptor = getModelDescriptor();
-        return descriptor != null ? descriptor.getOdooModel() : null;
+        return descriptor != null ? descriptor.odooModel() : null;
     }
 
     public ModelDescriptor getModelDescriptor() {

--- a/src/main/java/me/oddlyoko/odoo/models/reference/OdooModelReference.java
+++ b/src/main/java/me/oddlyoko/odoo/models/reference/OdooModelReference.java
@@ -1,0 +1,49 @@
+package me.oddlyoko.odoo.models.reference;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiElementResolveResult;
+import com.intellij.psi.PsiReferenceBase;
+import com.intellij.psi.ResolveResult;
+import com.jetbrains.python.psi.PyClass;
+import me.oddlyoko.odoo.models.OdooModelUtil;
+import me.oddlyoko.odoo.modules.OdooModuleUtil;
+import me.oddlyoko.odoo.modules.models.OdooModule;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public class OdooModelReference extends PsiReferenceBase.Poly<PsiElement> {
+    public OdooModelReference(PsiElement psiElement) {
+        super(psiElement);
+    }
+
+    @NotNull
+    @Override
+    public ResolveResult[] multiResolve(boolean incompleteCode) {
+        PsiElement element = getElement();
+        OdooModule odooModule = OdooModuleUtil.getModule(element);
+        if (odooModule == null)
+            return ResolveResult.EMPTY_ARRAY;
+        List<PyClass> pyClasses = OdooModelUtil.getModelsByName(getValue(), element.getProject(), odooModule);
+        return PsiElementResolveResult.createResults(pyClasses);
+    }
+
+    @NotNull
+    @Override
+    public Object[] getVariants() {
+        List<LookupElement> elements = new ArrayList<>();
+        PsiElement element = getElement();
+        OdooModule odooModule = OdooModuleUtil.getModule(element);
+        if (odooModule == null)
+            return new Object[0];
+
+        OdooModelUtil.getAllModels(element.getProject(), odooModule).forEach(s ->
+                elements.add(LookupElementBuilder.create(s)));
+        Collections.reverse(elements);
+        return elements.toArray();
+    }
+}

--- a/src/main/java/me/oddlyoko/odoo/models/reference/OdooModelReference.java
+++ b/src/main/java/me/oddlyoko/odoo/models/reference/OdooModelReference.java
@@ -1,6 +1,5 @@
 package me.oddlyoko.odoo.models.reference;
 
-import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiElementResolveResult;
@@ -12,8 +11,6 @@ import me.oddlyoko.odoo.modules.OdooModuleUtil;
 import me.oddlyoko.odoo.modules.models.OdooModule;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 public class OdooModelReference extends PsiReferenceBase.Poly<PsiElement> {
@@ -35,15 +32,12 @@ public class OdooModelReference extends PsiReferenceBase.Poly<PsiElement> {
     @NotNull
     @Override
     public Object[] getVariants() {
-        List<LookupElement> elements = new ArrayList<>();
         PsiElement element = getElement();
         OdooModule odooModule = OdooModuleUtil.getModule(element);
         if (odooModule == null)
             return new Object[0];
 
-        OdooModelUtil.getAllModels(element.getProject(), odooModule).forEach(s ->
-                elements.add(LookupElementBuilder.create(s)));
-        Collections.reverse(elements);
-        return elements.toArray();
+        return OdooModelUtil.getAllModels(element.getProject(), odooModule).stream()
+                .map(LookupElementBuilder::create).toArray();
     }
 }

--- a/src/main/java/me/oddlyoko/odoo/models/reference/OdooModelReferenceContributor.java
+++ b/src/main/java/me/oddlyoko/odoo/models/reference/OdooModelReferenceContributor.java
@@ -1,0 +1,34 @@
+package me.oddlyoko.odoo.models.reference;
+
+import com.intellij.patterns.PlatformPatterns;
+import com.intellij.patterns.PsiElementPattern;
+import com.intellij.psi.PsiElement;
+import com.intellij.psi.PsiReference;
+import com.intellij.psi.PsiReferenceContributor;
+import com.intellij.psi.PsiReferenceProvider;
+import com.intellij.psi.PsiReferenceRegistrar;
+import com.intellij.util.ProcessingContext;
+import com.jetbrains.python.PyTokenTypes;
+import com.jetbrains.python.psi.PyStringLiteralExpression;
+import com.jetbrains.python.psi.PyTargetExpression;
+import org.jetbrains.annotations.NotNull;
+
+public class OdooModelReferenceContributor extends PsiReferenceContributor {
+    public static final PsiElementPattern.Capture<? extends PsiElement> INHERIT_PATTERN =
+            PlatformPatterns.psiElement(PyStringLiteralExpression.class).afterSiblingSkipping(
+                    PlatformPatterns.psiElement().withElementType(PyTokenTypes.EQ),
+                    PlatformPatterns.psiElement(PyTargetExpression.class).withName("_inherit")
+            );
+
+    @Override
+    public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
+        PsiReferenceProvider provider = new PsiReferenceProvider() {
+            @NotNull
+            @Override
+            public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                return new PsiReference[] { new OdooModelReference(element) };
+            }
+        };
+        registrar.registerReferenceProvider(INHERIT_PATTERN, provider);
+    }
+}

--- a/src/main/java/me/oddlyoko/odoo/models/reference/OdooModelReferenceContributor.java
+++ b/src/main/java/me/oddlyoko/odoo/models/reference/OdooModelReferenceContributor.java
@@ -9,15 +9,43 @@ import com.intellij.psi.PsiReferenceProvider;
 import com.intellij.psi.PsiReferenceRegistrar;
 import com.intellij.util.ProcessingContext;
 import com.jetbrains.python.PyTokenTypes;
+import com.jetbrains.python.psi.PyDictLiteralExpression;
+import com.jetbrains.python.psi.PyListLiteralExpression;
+import com.jetbrains.python.psi.PySetLiteralExpression;
 import com.jetbrains.python.psi.PyStringLiteralExpression;
 import com.jetbrains.python.psi.PyTargetExpression;
 import org.jetbrains.annotations.NotNull;
 
 public class OdooModelReferenceContributor extends PsiReferenceContributor {
+    public static final PsiElementPattern.Capture<? extends PsiElement> NAME_PATTERN =
+            PlatformPatterns.psiElement(PyStringLiteralExpression.class).afterSiblingSkipping(
+                    PlatformPatterns.psiElement().withElementType(PyTokenTypes.EQ),
+                    PlatformPatterns.psiElement(PyTargetExpression.class).withName("_name")
+            );
     public static final PsiElementPattern.Capture<? extends PsiElement> INHERIT_PATTERN =
             PlatformPatterns.psiElement(PyStringLiteralExpression.class).afterSiblingSkipping(
                     PlatformPatterns.psiElement().withElementType(PyTokenTypes.EQ),
                     PlatformPatterns.psiElement(PyTargetExpression.class).withName("_inherit")
+            );
+    public static final PsiElementPattern.Capture<? extends PsiElement> INHERIT_DICT_PATTERN =
+            PlatformPatterns.psiElement(PyStringLiteralExpression.class).withParent(
+                    PlatformPatterns.psiElement(PyListLiteralExpression.class).afterSiblingSkipping(
+                            PlatformPatterns.psiElement().withElementType(PyTokenTypes.EQ),
+                            PlatformPatterns.psiElement(PyTargetExpression.class).withName("_inherit")
+                    )
+            );
+    public static final PsiElementPattern.Capture<? extends PsiElement> INHERITS_PATTERN =
+            PlatformPatterns.psiElement(PyStringLiteralExpression.class).withAncestor(2,
+                    PlatformPatterns.or(
+                            PlatformPatterns.psiElement(PyDictLiteralExpression.class).afterSiblingSkipping(
+                                    PlatformPatterns.psiElement().withElementType(PyTokenTypes.EQ),
+                                    PlatformPatterns.psiElement(PyTargetExpression.class).withName("_inherits")
+                            ),
+                            PlatformPatterns.psiElement(PySetLiteralExpression.class).afterSiblingSkipping(
+                                    PlatformPatterns.psiElement().withElementType(PyTokenTypes.EQ),
+                                    PlatformPatterns.psiElement(PyTargetExpression.class).withName("_inherits")
+                            )
+                    )
             );
 
     @Override
@@ -29,6 +57,9 @@ public class OdooModelReferenceContributor extends PsiReferenceContributor {
                 return new PsiReference[] { new OdooModelReference(element) };
             }
         };
+        registrar.registerReferenceProvider(NAME_PATTERN, provider);
         registrar.registerReferenceProvider(INHERIT_PATTERN, provider);
+        registrar.registerReferenceProvider(INHERIT_DICT_PATTERN, provider);
+        registrar.registerReferenceProvider(INHERITS_PATTERN, provider);
     }
 }

--- a/src/main/java/me/oddlyoko/odoo/modules/OdooModuleUtil.java
+++ b/src/main/java/me/oddlyoko/odoo/modules/OdooModuleUtil.java
@@ -15,7 +15,6 @@ import org.jetbrains.annotations.NotNull;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 public final class OdooModuleUtil {
     public static final List<String> MANIFEST_FILES = List.of(
@@ -101,7 +100,7 @@ public final class OdooModuleUtil {
         return odooModule.getModuleDepends()
                 .stream()
                 .map(s -> getModule(s, odooModule.getProject()))
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public static OdooModule getModuleFromDirectory(@NotNull PsiDirectory psiDirectory) {
@@ -134,14 +133,14 @@ public final class OdooModuleUtil {
     }
 
     public static OdooModule getModule(@NotNull PsiElement element) {
-        if (element instanceof PsiFile)
-            return getModuleFromFile((PsiFile) element);
-        if (element instanceof PsiDirectory)
-            return getModuleFromDirectory((PsiDirectory) element);
-        if (element instanceof PomTargetPsiElement) {
-            PomTarget target = ((PomTargetPsiElement) element).getTarget();
-            if (target instanceof PsiTarget)
-                return getModule(((PsiTarget) target).getNavigationElement());
+        if (element instanceof PsiFile psiFile)
+            return getModuleFromFile(psiFile);
+        if (element instanceof PsiDirectory psiDirectory)
+            return getModuleFromDirectory(psiDirectory);
+        if (element instanceof PomTargetPsiElement targetElement) {
+            PomTarget target = targetElement.getTarget();
+            if (target instanceof PsiTarget psiTarget)
+                return getModule(psiTarget.getNavigationElement());
         }
         return getModuleFromFile(element.getContainingFile().getOriginalFile());
     }

--- a/src/main/java/me/oddlyoko/odoo/modules/OdooModuleUtil.java
+++ b/src/main/java/me/oddlyoko/odoo/modules/OdooModuleUtil.java
@@ -143,7 +143,7 @@ public final class OdooModuleUtil {
             if (target instanceof PsiTarget)
                 return getModule(((PsiTarget) target).getNavigationElement());
         }
-        return getModuleFromFile(element.getContainingFile());
+        return getModuleFromFile(element.getContainingFile().getOriginalFile());
     }
 
     public static OdooModule getBaseModule(@NotNull Project project) {

--- a/src/main/java/me/oddlyoko/odoo/modules/indexes/OdooModuleDependencyIndex.java
+++ b/src/main/java/me/oddlyoko/odoo/modules/indexes/OdooModuleDependencyIndex.java
@@ -48,7 +48,7 @@ public class OdooModuleDependencyIndex extends ScalarIndexExtension<String> {
             ModuleDescriptor descriptor = ModuleDescriptor.parseFile(file);
             if (descriptor == null)
                 return result;
-            descriptor.getDepends().forEach(s -> result.put(s, null));
+            descriptor.depends().forEach(s -> result.put(s, null));
             return result;
         };
     }

--- a/src/main/java/me/oddlyoko/odoo/modules/models/ModuleDescriptor.java
+++ b/src/main/java/me/oddlyoko/odoo/modules/models/ModuleDescriptor.java
@@ -19,105 +19,10 @@ import java.util.Map;
  * A description of a module.<br />
  * Data is taken from manifest file
  */
-public final class ModuleDescriptor {
-    private final PsiDirectory directory;
-    private final PsiFile manifest;
-    private final String id;
-    private final String name;
-    private final String version;
-    private final String description;
-    private final List<String> author;
-    private final String website;
-    private final List<String> depends;
-    private final List<String> data;
-    private final List<String> demo;
-    private final String license;
+public record ModuleDescriptor(PsiDirectory directory, PsiFile manifest, String id, String name, String version,
+                               String description, List<String> author, String website, List<String> depends,
+                               List<String> data, List<String> demo, String license) {
 
-    public ModuleDescriptor(@NotNull PsiDirectory directory,
-                            @NotNull PsiFile manifest,
-                            @NotNull String id,
-                            @NotNull String name,
-                            @NotNull String version,
-                            @NotNull String description,
-                            @NotNull List<String> author,
-                            @NotNull String website,
-                            @NotNull List<String> depends,
-                            @NotNull List<String> data,
-                            @NotNull List<String> demo,
-                            @NotNull String license) {
-        this.directory = directory;
-        this.manifest = manifest;
-        this.id = id;
-        this.name = name;
-        this.version = version;
-        this.description = description;
-        this.author = author;
-        this.website = website;
-        this.depends = depends;
-        this.data = data;
-        this.demo = demo;
-        this.license = license;
-    }
-
-    @NotNull
-    public PsiDirectory getDirectory() {
-        return directory;
-    }
-
-    @NotNull
-    public PsiFile getManifest() {
-        return manifest;
-    }
-
-    @NotNull
-    public String getId() {
-        return id;
-    }
-
-    @NotNull
-    public String getName() {
-        return name;
-    }
-
-    @NotNull
-    public String getVersion() {
-        return version;
-    }
-
-    @NotNull
-    public String getDescription() {
-        return description;
-    }
-
-    @NotNull
-    public List<String> getAuthor() {
-        return author;
-    }
-
-    @NotNull
-    public String getWebsite() {
-        return website;
-    }
-
-    @NotNull
-    public List<String> getDepends() {
-        return depends;
-    }
-
-    @NotNull
-    public List<String> getData() {
-        return data;
-    }
-
-    @NotNull
-    public List<String> getDemo() {
-        return demo;
-    }
-
-    @NotNull
-    public String getLicense() {
-        return license;
-    }
 
     @Override
     public String toString() {
@@ -146,44 +51,44 @@ public final class ModuleDescriptor {
             String key = entry.getKey();
             PyExpression value = entry.getValue();
             switch (key) {
-                case "name":
-                    if (value instanceof PyStringLiteralExpression)
-                        name = ((PyStringLiteralExpression) value).getStringValue();
-                    break;
-                case "version":
-                    if (value instanceof PyStringLiteralExpression)
-                        version = ((PyStringLiteralExpression) value).getStringValue();
-                    break;
-                case "description":
-                    if (value instanceof PyStringLiteralExpression)
-                        description = ((PyStringLiteralExpression) value).getStringValue();
-                    break;
-                case "author":
-                    if (value instanceof PyStringLiteralExpression)
-                        authors = List.of(((PyStringLiteralExpression) value).getStringValue());
-                    else if (value instanceof PySequenceExpression)
-                        authors = sequenceToList((PySequenceExpression) value);
-                    break;
-                case "website":
-                    if (value instanceof PyStringLiteralExpression)
-                        website = ((PyStringLiteralExpression) value).getStringValue();
-                    break;
-                case "depends":
-                    if (value instanceof PySequenceExpression)
-                        depends = sequenceToList((PySequenceExpression) value);
-                    break;
-                case "data":
-                    if (value instanceof PySequenceExpression)
-                        data = sequenceToList((PySequenceExpression) value);
-                    break;
-                case "demo":
-                    if (value instanceof PySequenceExpression)
-                        demo = sequenceToList((PySequenceExpression) value);
-                    break;
-                case "license":
-                    if (value instanceof PyStringLiteralExpression)
-                        license = ((PyStringLiteralExpression) value).getStringValue();
-                    break;
+                case "name" -> {
+                    if (value instanceof PyStringLiteralExpression stringExpression)
+                        name = stringExpression.getStringValue();
+                }
+                case "version" -> {
+                    if (value instanceof PyStringLiteralExpression stringExpression)
+                        version = stringExpression.getStringValue();
+                }
+                case "description" -> {
+                    if (value instanceof PyStringLiteralExpression stringExpression)
+                        description = stringExpression.getStringValue();
+                }
+                case "author" -> {
+                    if (value instanceof PyStringLiteralExpression stringExpression)
+                        authors = List.of(stringExpression.getStringValue());
+                    else if (value instanceof PySequenceExpression sequenceExpression)
+                        authors = sequenceToList(sequenceExpression);
+                }
+                case "website" -> {
+                    if (value instanceof PyStringLiteralExpression stringExpression)
+                        website = stringExpression.getStringValue();
+                }
+                case "depends" -> {
+                    if (value instanceof PySequenceExpression sequenceExpression)
+                        depends = sequenceToList(sequenceExpression);
+                }
+                case "data" -> {
+                    if (value instanceof PySequenceExpression sequenceExpression)
+                        data = sequenceToList(sequenceExpression);
+                }
+                case "demo" -> {
+                    if (value instanceof PySequenceExpression sequenceExpression)
+                        demo = sequenceToList(sequenceExpression);
+                }
+                case "license" -> {
+                    if (value instanceof PyStringLiteralExpression stringExpression)
+                        license = stringExpression.getStringValue();
+                }
             }
         }
         return new ModuleDescriptor(module,

--- a/src/main/java/me/oddlyoko/odoo/modules/models/OdooModule.java
+++ b/src/main/java/me/oddlyoko/odoo/modules/models/OdooModule.java
@@ -18,7 +18,6 @@ import org.jetbrains.annotations.NotNull;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
@@ -75,11 +74,11 @@ public final class OdooModule {
                 result.addAll(module.getModuleDepends());
             }
         }
-        return result.stream().distinct().collect(Collectors.toUnmodifiableList());
+        return result.stream().distinct().toList();
     }
 
     public List<OdooModule> getOdooModuleDepends() {
-        return getModuleDepends().stream().map(s -> OdooModuleUtil.getModule(s, getProject())).collect(Collectors.toList());
+        return getModuleDepends().stream().map(s -> OdooModuleUtil.getModule(s, getProject())).toList();
     }
 
     /**
@@ -95,7 +94,7 @@ public final class OdooModule {
         if (includeThisOne)
             stream = Stream.concat(Stream.of(this), stream);
 
-        return stream.filter(Objects::nonNull).distinct().collect(Collectors.toList());
+        return stream.filter(Objects::nonNull).distinct().toList();
     }
 
     /**
@@ -108,7 +107,7 @@ public final class OdooModule {
     }
 
     public List<OdooModule> getDirectOdooModuleDepends() {
-        return getDirectModuleDepends().stream().map(s -> OdooModuleUtil.getModule(s, getProject())).collect(Collectors.toList());
+        return getDirectModuleDepends().stream().map(s -> OdooModuleUtil.getModule(s, getProject())).toList();
     }
 
     public List<OdooModule> getOdooModuleDepending() {
@@ -141,7 +140,7 @@ public final class OdooModule {
 
         return getOdooModuleDepends(true).stream()
                 .flatMap(odooModule -> odooModule.getVirtualFiles(false).stream())
-                .collect(Collectors.toList());
+                .toList();
     }
 
     /**
@@ -152,7 +151,7 @@ public final class OdooModule {
     public List<VirtualFile> getPythonFiles(boolean includeDepends) {
         return getVirtualFiles(includeDepends).stream()
                 .filter(file -> file.getFileType() == PythonFileType.INSTANCE)
-                .collect(Collectors.toList());
+                .toList();
     }
 
     public List<String> getModels(boolean includeDepends) {

--- a/src/main/java/me/oddlyoko/odoo/modules/reference/OdooManifestReferenceContributor.java
+++ b/src/main/java/me/oddlyoko/odoo/modules/reference/OdooManifestReferenceContributor.java
@@ -31,14 +31,13 @@ public class OdooManifestReferenceContributor extends PsiReferenceContributor {
 
     @Override
     public void registerReferenceProviders(@NotNull PsiReferenceRegistrar registrar) {
-        registrar.registerReferenceProvider(DEPENDS_PATTERN,
-                new PsiReferenceProvider() {
-                    @NotNull
-                    @Override
-                    public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
-                        return new PsiReference[] { new OdooModuleReference(element) };
-                    }
-                });
+        registrar.registerReferenceProvider(DEPENDS_PATTERN, new PsiReferenceProvider() {
+            @NotNull
+            @Override
+            public PsiReference[] getReferencesByElement(@NotNull PsiElement element, @NotNull ProcessingContext context) {
+                return new PsiReference[] { new OdooModuleReference(element) };
+            }
+        });
         registrar.registerReferenceProvider(DATA_PATTERN,
                 new PsiReferenceProvider() {
                     @NotNull

--- a/src/main/java/me/oddlyoko/odoo/modules/reference/OdooManifestReferenceListCondition.java
+++ b/src/main/java/me/oddlyoko/odoo/modules/reference/OdooManifestReferenceListCondition.java
@@ -31,10 +31,10 @@ public class OdooManifestReferenceListCondition extends PatternCondition<PyStrin
         PsiElement parent = pyString.getParent();
         if (parent instanceof PyListLiteralExpression) {
             parent = parent.getParent();
-            if (parent instanceof PyKeyValueExpression) {
-                PyExpression key = ((PyKeyValueExpression) parent).getKey();
-                if (key instanceof PyStringLiteralExpression)
-                    return acceptedKeys.contains(((PyStringLiteralExpression) key).getStringValue());
+            if (parent instanceof PyKeyValueExpression parentExpression) {
+                PyExpression key = parentExpression.getKey();
+                if (key instanceof PyStringLiteralExpression keyExpression)
+                    return acceptedKeys.contains(keyExpression.getStringValue());
             }
         }
         return false;

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -11,6 +11,12 @@
     <change-notes><![CDATA[
     <ul>
         <li>
+            Version alpha 0.0.3
+            <ul>
+                <li>Add autocompletion with inherit</li>
+            </ul>
+        </li>
+        <li>
             Version alpha 0.0.2
             <ul>
                 <li>Fix issue with PyCharm version</li>
@@ -37,6 +43,7 @@
         <fileBasedIndex implementation="me.oddlyoko.odoo.models.indexes.OdooModelIndex" />
 
         <psi.referenceContributor implementation="me.oddlyoko.odoo.modules.reference.OdooManifestReferenceContributor" />
+        <psi.referenceContributor implementation="me.oddlyoko.odoo.models.reference.OdooModelReferenceContributor" />
         <lang.parserDefinition implementationClass="me.oddlyoko.odoo.python.OdooPythonParserDefinition" language="Python" order="first" />
 
         <psi.treeChangePreprocessor implementation="me.oddlyoko.odoo.modules.listener.OdooModuleModificationListener" />

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -14,6 +14,8 @@
             Version alpha 0.0.3
             <ul>
                 <li>Add autocompletion with _name, _inherit and _inherits</li>
+                <li>Update to Java 17</li>
+                <li>Update to PyCharm version 2022.2</li>
             </ul>
         </li>
         <li>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -13,7 +13,7 @@
         <li>
             Version alpha 0.0.3
             <ul>
-                <li>Add autocompletion with inherit</li>
+                <li>Add autocompletion with _name, _inherit and _inherits</li>
             </ul>
         </li>
         <li>


### PR DESCRIPTION
Add support for `_name`, `_inherit` and `_inherits`
Update to PyCharm 2022.2
Use now Java 17